### PR TITLE
Use correct strikeout command

### DIFF
--- a/conf/conf.xml
+++ b/conf/conf.xml
@@ -410,7 +410,7 @@
   <template context="dbk:phrase[@css:text-decoration-line eq 'line-through'
                                 or exists(for $i in ./@role 
                                           return /dbk:hub/dbk:info/css:rules/css:rule[$i eq @name][@css:text-decoration-line eq 'line-through'])]">
-    <xsl:text>\sout{</xsl:text>
+    <xsl:text>\st{</xsl:text>
     <xsl:next-match/>
     <xsl:text>}</xsl:text>
   </template>


### PR DESCRIPTION
\sout is from ulem, whereas docx2tex uses soul by default (now for \ul). Therefore use \st so output successfully compiles.